### PR TITLE
feat: add extra_qualifiers and extra_env_keys hooks for subclass reso…

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,4 +1,6 @@
 # Relax rules for project documentation style
 MD013: false # Line length — handled by prettier
+MD024:
+  siblings_only: true # Allow repeated headings across changelog versions
 MD033: false # Inline HTML — needed for badges and layout in README
 MD041: false # First line should be top-level heading — READMEs use HTML header

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,18 +19,18 @@
 
 ### 🚀 Features
 
-* feat: Add CodSpeed continuous performance benchmarks (#39) @codspeed-hq
+- feat: Add CodSpeed continuous performance benchmarks (#39) @codspeed-hq
 
 ### 🐛 Bug Fixes
 
-* fix(ci): skip release notes on non-release, fix labeler retriggering (#38) @codelluis
-* fix(ci): fix dependabot commit prefix and PyPI publish (#35) @codelluis
-* fix(ci): group dependabot PRs, add crate readmes, fix tag race (#32) @codelluis
+- fix(ci): skip release notes on non-release, fix labeler retriggering (#38) @codelluis
+- fix(ci): fix dependabot commit prefix and PyPI publish (#35) @codelluis
+- fix(ci): group dependabot PRs, add crate readmes, fix tag race (#32) @codelluis
 
 ### 🧰 Maintenance
 
-* chore: bump the rust-dependencies group with 2 updates (#36) @dependabot
-* ci: bump the github-actions group with 14 updates (#37) @dependabot
+- chore: bump the rust-dependencies group with 2 updates (#36) @dependabot
+- ci: bump the github-actions group with 14 updates (#37) @dependabot
 
 ## 0.1.0 (unreleased)
 
@@ -55,6 +55,7 @@
 ### Infrastructure
 
 - CI/CD: GitHub Actions aligned with rustvello/pynenc conventions
+
   - `main.yml`: quality, tests (matrix: ubuntu/macos × py3.12/3.13), docs, publish dry-run
   - `release-rust.yml`: publish cistell-macros and cistell-core to crates.io
   - `release-python.yml`: multi-platform wheels (Linux x86_64/aarch64, macOS x86_64/arm64, Windows)
@@ -63,7 +64,7 @@
   - `pr-title-checker.yml`: enforce conventional commit PR titles
   - `publish-release-notes.yml`: auto-publish release notes and update CHANGELOG
   - `smokeshow.yml`: coverage report hosting
-  
+
 - Pre-commit hooks: cargo-fmt, cargo-clippy, ruff, mypy, commitlint, typos, markdownlint, prettier
 - Makefile: install, check, build, test, publish-rust, publish-python, docs targets
 - Docs: Sphinx + furo theme with grid cards, Rust/Python dual-ecosystem messaging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 0.1.2 (2026-04-08)
+
+### Added
+
+- `resolve_field()` now accepts optional `extra_qualifiers` and `extra_env_keys`
+  keyword arguments, allowing subclasses to inject higher-priority mapping
+  subsections and environment variable keys without reimplementing the
+  resolution loop.
+- `ConfigBase.get_extra_qualifiers()` hook — override to add qualifier
+  subsection keys (e.g., task-specific config sections).
+- `ConfigBase.get_extra_env_keys()` hook — override to add extra env-var
+  keys per field (e.g., task-specific env vars).
+
 ## 0.1.1 - 2026-04-07
 
 ### What's Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,7 +113,7 @@ dependencies = [
 
 [[package]]
 name = "cistell-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cistell-macros",
  "codspeed-criterion-compat",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "cistell-macros"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -141,7 +141,7 @@ dependencies = [
 
 [[package]]
 name = "cistell-py"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "cistell-core",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/*"]
 default-members = ["crates/cistell-core", "crates/cistell-macros"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 rust-version = "1.85"
 homepage = "https://pynenc.org"
@@ -15,9 +15,9 @@ keywords = ["configuration", "config", "settings", "env"]
 categories = ["config"]
 
 [workspace.dependencies]
-cistell-core   = { version = "0.1.1", path = "crates/cistell-core" }
-cistell-macros = { version = "0.1.1", path = "crates/cistell-macros" }
-cistell-py     = { version = "0.1.1", path = "crates/cistell-py" }
+cistell-core   = { version = "0.1.2", path = "crates/cistell-core" }
+cistell-macros = { version = "0.1.2", path = "crates/cistell-macros" }
+cistell-py     = { version = "0.1.2", path = "crates/cistell-py" }
 
 pyo3       = { version = "0.28", features = ["multiple-pymethods"] }
 serde      = { version = "1", features = ["derive"] }

--- a/cistell/_internal.pyi
+++ b/cistell/_internal.pyi
@@ -35,4 +35,6 @@ def resolve_field(
     secret: bool = False,
     mappings: list[tuple[str, dict[str, Any]]] | None = None,
     mapped_keys: set[str] | None = None,
+    extra_qualifiers: list[str] | None = None,
+    extra_env_keys: list[str] | None = None,
 ) -> tuple[Any, FieldProvenance] | None: ...

--- a/cistell/base.py
+++ b/cistell/base.py
@@ -61,6 +61,35 @@ class ConfigBase(ConfigRoot):
     and `ConfigRedis`.
     """
 
+    def get_extra_qualifiers(
+        self,
+        config_cls: type["ConfigRoot"],
+    ) -> list[str] | None:
+        """Return extra qualifier subsection keys for mapping lookups.
+
+        Override this in subclasses to add higher-priority subsections.
+        For example, returning ``["module_name.task_name"]`` causes
+        ``mapping[config_id]["module_name.task_name"][field_name]`` to be
+        checked after the class-specific ``mapping[config_id][field_name]``.
+        """
+        del config_cls
+        return None
+
+    def get_extra_env_keys(
+        self,
+        field_name: str,
+        config_cls: type["ConfigRoot"],
+    ) -> list[str] | None:
+        """Return extra env-var keys to check for *field_name*.
+
+        Override this in subclasses to add higher-priority env vars.
+        For example, returning ``["MODULE#FUNC__MAX_RETRIES"]`` causes
+        that env var to be checked after the standard class and generic
+        env vars.
+        """
+        del field_name, config_cls
+        return None
+
     def init_parent_values(
         self,
         config_cls: type["ConfigRoot"],
@@ -115,6 +144,7 @@ class ConfigBase(ConfigRoot):
             ))
 
         # Resolve each field via Rust
+        extra_qualifiers = self.get_extra_qualifiers(config_cls)
         for field_name in self.config_cls_to_fields.get(config_cls.__name__, set()):
             field = self._get_field_descriptor(field_name)
             if field is None:
@@ -127,6 +157,8 @@ class ConfigBase(ConfigRoot):
                 secret=field._secret,
                 mappings=mappings,
                 mapped_keys=self._mapped_keys,
+                extra_qualifiers=extra_qualifiers,
+                extra_env_keys=self.get_extra_env_keys(field_name, config_cls),
             )
             if result is not None:
                 value, prov = result

--- a/crates/cistell-py/src/lib.rs
+++ b/crates/cistell-py/src/lib.rs
@@ -155,6 +155,83 @@ fn load_config_file(py: Python<'_>, path: &str, config_id: Option<&str>) -> PyRe
 }
 
 // ---------------------------------------------------------------------------
+// resolve_field – helpers
+// ---------------------------------------------------------------------------
+
+/// Walk `dict[keys[0]][keys[1]]…`, casting each intermediate value to [`PyDict`].
+///
+/// Returns `None` when any key is absent or any intermediate is not a dict.
+fn dict_chain_get<'py>(
+    dict: &Bound<'py, PyDict>,
+    keys: &[&str],
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    let Some((&first, rest)) = keys.split_first() else {
+        return Ok(None);
+    };
+    let Some(mut current) = dict.get_item(first)? else {
+        return Ok(None);
+    };
+    for key in rest {
+        let next = {
+            let Ok(sub) = current.cast::<PyDict>() else {
+                return Ok(None);
+            };
+            sub.get_item(key)?
+        };
+        match next {
+            Some(val) => current = val,
+            None => return Ok(None),
+        }
+    }
+    Ok(Some(current))
+}
+
+/// Look up a value in `mapping` via a chain of dict keys, guarded by `mapped_keys`.
+///
+/// If the composite key is already in `mapped_keys` the lookup is skipped
+/// (returns `None`).  On a successful find the composite key is recorded in
+/// `mapped_keys` to prevent duplicate application in multi-inheritance.
+fn try_mapping_lookup<'py>(
+    mapping: &Bound<'py, PyDict>,
+    keys: &[&str],
+    composite_key: &str,
+    mapped_keys: Option<&Bound<'py, PySet>>,
+) -> PyResult<Option<Bound<'py, PyAny>>> {
+    if let Some(mk) = mapped_keys {
+        if mk.contains(composite_key)? {
+            return Ok(None);
+        }
+    }
+    let Some(val) = dict_chain_get(mapping, keys)? else {
+        return Ok(None);
+    };
+    if let Some(mk) = mapped_keys {
+        mk.add(composite_key)?;
+    }
+    Ok(Some(val))
+}
+
+/// Try to read an environment variable and wrap it as a Python string with provenance.
+fn resolve_env_var(
+    py: Python<'_>,
+    key: &str,
+    secret: bool,
+) -> PyResult<Option<(Py<PyAny>, FieldProvenance)>> {
+    let Ok(val) = std::env::var(key) else {
+        return Ok(None);
+    };
+    Ok(Some((
+        val.into_pyobject(py)?.into_any().unbind(),
+        FieldProvenance {
+            source: format!("env var '{key}'"),
+            is_default: false,
+            is_secret: secret,
+            display_value: None,
+        },
+    )))
+}
+
+// ---------------------------------------------------------------------------
 // resolve_field
 // ---------------------------------------------------------------------------
 
@@ -166,8 +243,16 @@ fn load_config_file(py: Python<'_>, path: &str, config_id: Option<&str>) -> PyRe
 /// The `mapped_keys` set prevents the same `"{source}##{field}"` pair from
 /// being applied twice (critical for multi-inheritance).
 ///
+/// **Qualifier subsections** (`extra_qualifiers`) are checked after the
+/// class-specific subsection with even higher priority.  For example, pynenc
+/// passes `["module_name.task_name"]` so that a YAML section like
+/// `task: { module_name.task_name: { max_retries: 5 } }` overrides the
+/// class-level `task: { max_retries: 10 }`.
+///
 /// **Env vars** (highest priority) always override; they are not gated by
-/// `mapped_keys`.
+/// `mapped_keys`.  When `extra_env_keys` is provided, those keys are checked
+/// **after** `class_env_key` and `generic_env_key`, giving them the highest
+/// possible priority.
 ///
 /// Returns `Some((value, FieldProvenance))` when a source provides a value,
 /// or `None` when nothing was found (caller should keep any previously-set
@@ -182,6 +267,8 @@ fn load_config_file(py: Python<'_>, path: &str, config_id: Option<&str>) -> PyRe
     secret = false,
     mappings = None,
     mapped_keys = None,
+    extra_qualifiers = None,
+    extra_env_keys = None,
 ))]
 #[allow(clippy::too_many_arguments)]
 fn resolve_field<'py>(
@@ -193,6 +280,8 @@ fn resolve_field<'py>(
     secret: bool,
     mappings: Option<&Bound<'py, PyList>>,
     mapped_keys: Option<&Bound<'py, PySet>>,
+    extra_qualifiers: Option<&Bound<'py, PyList>>,
+    extra_env_keys: Option<&Bound<'py, PyList>>,
 ) -> PyResult<Option<(Py<PyAny>, FieldProvenance)>> {
     let mut current_value: Option<Py<PyAny>> = None;
     let mut current_source = String::new();
@@ -207,36 +296,36 @@ fn resolve_field<'py>(
 
             // --- generic: mapping[field_name] ---
             let general_key = format!("{source_name}##{field_name}");
-            let check_general = match mapped_keys {
-                Some(keys) => !keys.contains(&general_key)?,
-                None => true,
-            };
-            if check_general {
-                if let Some(val) = mapping.get_item(field_name)? {
-                    current_value = Some(val.unbind());
-                    current_source.clone_from(&source_name);
-                    if let Some(keys) = mapped_keys {
-                        keys.add(&general_key)?;
-                    }
-                }
+            if let Some(val) =
+                try_mapping_lookup(mapping, &[field_name], &general_key, mapped_keys)?
+            {
+                current_value = Some(val.unbind());
+                current_source.clone_from(&source_name);
             }
 
             // --- class-specific: mapping[config_id][field_name] ---
             let class_key = format!("{source_name}##{config_id}##{field_name}");
-            let check_class = match mapped_keys {
-                Some(keys) => !keys.contains(&class_key)?,
-                None => true,
-            };
-            if check_class {
-                if let Some(conf_obj) = mapping.get_item(config_id)? {
-                    if let Ok(conf_dict) = conf_obj.cast::<PyDict>() {
-                        if let Some(val) = conf_dict.get_item(field_name)? {
-                            current_value = Some(val.unbind());
-                            current_source.clone_from(&source_name);
-                            if let Some(keys) = mapped_keys {
-                                keys.add(&class_key)?;
-                            }
-                        }
+            if let Some(val) =
+                try_mapping_lookup(mapping, &[config_id, field_name], &class_key, mapped_keys)?
+            {
+                current_value = Some(val.unbind());
+                current_source.clone_from(&source_name);
+            }
+
+            // --- qualifier subsections: mapping[config_id][qualifier][field_name] ---
+            // Higher priority than class-specific; later qualifiers win.
+            if let Some(qualifiers) = extra_qualifiers {
+                for qual_item in qualifiers.iter() {
+                    let qualifier: String = qual_item.extract()?;
+                    let qual_key = format!("{source_name}##{config_id}##{qualifier}##{field_name}");
+                    if let Some(val) = try_mapping_lookup(
+                        mapping,
+                        &[config_id, &qualifier, field_name],
+                        &qual_key,
+                        mapped_keys,
+                    )? {
+                        current_value = Some(val.unbind());
+                        current_source.clone_from(&source_name);
                     }
                 }
             }
@@ -244,27 +333,21 @@ fn resolve_field<'py>(
     }
 
     // 2. Env vars (highest priority, always override).
-    if let Ok(val) = std::env::var(class_env_key) {
-        return Ok(Some((
-            val.into_pyobject(py)?.into_any().unbind(),
-            FieldProvenance {
-                source: format!("env var '{class_env_key}'"),
-                is_default: false,
-                is_secret: secret,
-                display_value: None,
-            },
-        )));
+    // Extra env keys have the highest priority; checked first so they win.
+    if let Some(extra_keys) = extra_env_keys {
+        // Iterate in reverse so the last key in the list has highest priority.
+        for key_item in extra_keys.iter().rev() {
+            let env_key: String = key_item.extract()?;
+            if let Some(result) = resolve_env_var(py, &env_key, secret)? {
+                return Ok(Some(result));
+            }
+        }
     }
-    if let Ok(val) = std::env::var(generic_env_key) {
-        return Ok(Some((
-            val.into_pyobject(py)?.into_any().unbind(),
-            FieldProvenance {
-                source: format!("env var '{generic_env_key}'"),
-                is_default: false,
-                is_secret: secret,
-                display_value: None,
-            },
-        )));
+    if let Some(result) = resolve_env_var(py, class_env_key, secret)? {
+        return Ok(Some(result));
+    }
+    if let Some(result) = resolve_env_var(py, generic_env_key, secret)? {
+        return Ok(Some(result));
     }
 
     // 3. Return mapping result or None.

--- a/tests/unit/test_extra_qualifiers_env_keys.py
+++ b/tests/unit/test_extra_qualifiers_env_keys.py
@@ -1,0 +1,123 @@
+"""Tests for extra_qualifiers and extra_env_keys hooks in ConfigBase."""
+
+from __future__ import annotations
+
+import os
+
+from typing import TYPE_CHECKING
+
+from cistell import ConfigBase, ConfigField
+
+if TYPE_CHECKING:
+    from cistell.root import ConfigRoot
+
+
+class TaskConfig(ConfigBase):
+    """A config that uses extra qualifiers and env keys (like pynenc's ConfigTask)."""
+
+    max_retries = ConfigField(3)
+    timeout = ConfigField(30)
+
+    def __init__(
+        self,
+        task_key: str | None = None,
+        **kwargs,
+    ) -> None:
+        self._task_key = task_key
+        super().__init__(**kwargs)
+
+    def get_extra_qualifiers(self, config_cls: type[ConfigRoot]) -> list[str] | None:
+        if self._task_key:
+            return [self._task_key]
+        return None
+
+    def get_extra_env_keys(
+        self, field_name: str, config_cls: type[ConfigRoot]
+    ) -> list[str] | None:
+        if self._task_key:
+            return [f"TASK_{self._task_key.upper()}__{field_name.upper()}"]
+        return None
+
+
+class TestExtraQualifiers:
+    def test_no_qualifiers_uses_default(self) -> None:
+        cfg = TaskConfig()
+        assert cfg.max_retries == 3
+
+    def test_qualifier_picks_up_subsection(self) -> None:
+        config_values = {
+            "task": {
+                "max_retries": 10,
+                "my_module.my_task": {
+                    "max_retries": 42,
+                },
+            },
+        }
+        cfg = TaskConfig(task_key="my_module.my_task", config_values=config_values)
+        assert cfg.max_retries == 42
+
+    def test_qualifier_without_match_falls_back_to_class(self) -> None:
+        config_values = {
+            "task": {
+                "max_retries": 10,
+            },
+        }
+        cfg = TaskConfig(task_key="my_module.my_task", config_values=config_values)
+        assert cfg.max_retries == 10
+
+    def test_qualifier_only_affects_matched_fields(self) -> None:
+        config_values = {
+            "task": {
+                "max_retries": 10,
+                "timeout": 60,
+                "my_module.my_task": {
+                    "max_retries": 42,
+                },
+            },
+        }
+        cfg = TaskConfig(task_key="my_module.my_task", config_values=config_values)
+        assert cfg.max_retries == 42
+        assert cfg.timeout == 60
+
+
+class TestExtraEnvKeys:
+    def test_extra_env_key_overrides(self) -> None:
+        env_key = "TASK_MY_MODULE.MY_TASK__MAX_RETRIES"
+        os.environ[env_key] = "99"
+        try:
+            cfg = TaskConfig(task_key="my_module.my_task")
+            assert cfg.max_retries == 99
+        finally:
+            del os.environ[env_key]
+
+    def test_extra_env_key_beats_class_env_key(self) -> None:
+        class_key = TaskConfig.get_env_key("max_retries", TaskConfig)
+        task_key = "TASK_MY_MODULE.MY_TASK__MAX_RETRIES"
+        os.environ[class_key] = "50"
+        os.environ[task_key] = "99"
+        try:
+            cfg = TaskConfig(task_key="my_module.my_task")
+            assert cfg.max_retries == 99
+        finally:
+            del os.environ[class_key]
+            del os.environ[task_key]
+
+    def test_extra_env_key_beats_qualifier(self) -> None:
+        env_key = "TASK_MY_MODULE.MY_TASK__MAX_RETRIES"
+        os.environ[env_key] = "99"
+        config_values = {
+            "task": {
+                "my_module.my_task": {
+                    "max_retries": 42,
+                },
+            },
+        }
+        try:
+            cfg = TaskConfig(task_key="my_module.my_task", config_values=config_values)
+            assert cfg.max_retries == 99
+        finally:
+            del os.environ[env_key]
+
+    def test_no_task_key_ignores_extra_env(self) -> None:
+        cfg = TaskConfig()
+        assert cfg.max_retries == 3

--- a/tests/unit/test_resolve_helpers.py
+++ b/tests/unit/test_resolve_helpers.py
@@ -1,0 +1,433 @@
+"""Tests for resolve_field helper functions (dict_chain_get, try_mapping_lookup, resolve_env_var).
+
+These exercise the internal Rust helpers through the public ``resolve_field``
+FFI boundary, covering edge-cases that higher-level ConfigBase tests don't
+reach.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+from cistell._internal import resolve_field
+
+# ---------------------------------------------------------------------------
+# Fixtures / constants
+# ---------------------------------------------------------------------------
+
+FIELD = "timeout"
+CONFIG_ID = "myapp"
+CLASS_ENV = f"MYAPP__{FIELD}".upper()
+GENERIC_ENV = FIELD.upper()
+
+
+def _mapping(source_name: str, data: dict) -> list[tuple[str, dict]]:
+    """Wrap *data* as a single-source mapping list expected by resolve_field."""
+    return [(source_name, data)]
+
+
+# ---------------------------------------------------------------------------
+# dict_chain_get — tested via mapping resolution depth
+# ---------------------------------------------------------------------------
+
+
+class TestDictChainGet:
+    """Exercise ``dict_chain_get`` through mapping lookups at different depths."""
+
+    def test_single_key_generic_lookup(self) -> None:
+        """mapping[field_name] — single key chain."""
+        mappings = _mapping("src", {FIELD: 42})
+        val, prov = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert val == 42
+        assert prov.source == "src"
+
+    def test_two_key_class_specific_lookup(self) -> None:
+        """mapping[config_id][field_name] — two-key chain."""
+        mappings = _mapping("src", {CONFIG_ID: {FIELD: 99}})
+        val, _prov = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert val == 99
+
+    def test_three_key_qualifier_lookup(self) -> None:
+        """mapping[config_id][qualifier][field_name] — three-key chain."""
+        mappings = _mapping("src", {CONFIG_ID: {"qual.key": {FIELD: 7}}})
+        result = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            extra_qualifiers=["qual.key"],
+        )
+        assert result is not None
+        val, _ = result
+        assert val == 7
+
+    def test_missing_intermediate_key_returns_none(self) -> None:
+        """mapping[config_id] missing → class-specific lookup yields nothing."""
+        mappings = _mapping("src", {"other_id": {FIELD: 1}})
+        result = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        # generic key not present either → None
+        assert result is None
+
+    def test_non_dict_intermediate_is_skipped(self) -> None:
+        """mapping[config_id] is a non-dict value → treated as absent."""
+        mappings = _mapping("src", {CONFIG_ID: "not-a-dict"})
+        result = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert result is None
+
+    def test_qualifier_non_dict_intermediate_is_skipped(self) -> None:
+        """mapping[config_id][qualifier] is a non-dict → qualifier lookup skipped."""
+        mappings = _mapping("src", {CONFIG_ID: {"qual": "oops", FIELD: 5}})
+        result = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            extra_qualifiers=["qual"],
+        )
+        # Falls back to class-specific lookup for field_name
+        assert result is not None
+        val, _ = result
+        assert val == 5
+
+    def test_empty_mapping_dict_returns_none(self) -> None:
+        mappings = _mapping("src", {})
+        result = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert result is None
+
+    def test_no_mappings_returns_none(self) -> None:
+        result = resolve_field(FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# try_mapping_lookup — mapped_keys dedup behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestTryMappingLookup:
+    """Exercise ``try_mapping_lookup`` mapped_keys dedup logic."""
+
+    def test_mapped_keys_prevents_duplicate_generic(self) -> None:
+        """A generic key already in mapped_keys is not applied again."""
+        mapped_keys: set[str] = set()
+        mappings = _mapping("s1", {FIELD: 10})
+
+        # First call — records the key
+        val1, _ = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            mapped_keys=mapped_keys,
+        )
+        assert val1 == 10
+        assert f"s1##{FIELD}" in mapped_keys
+
+        # Second call with the same source — should be skipped
+        mappings2 = _mapping("s1", {FIELD: 999})
+        result = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings2,
+            mapped_keys=mapped_keys,
+        )
+        assert result is None
+
+    def test_mapped_keys_prevents_duplicate_class_specific(self) -> None:
+        mapped_keys: set[str] = set()
+        mappings = _mapping("s1", {CONFIG_ID: {FIELD: 20}})
+
+        val1, _ = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            mapped_keys=mapped_keys,
+        )
+        assert val1 == 20
+        assert f"s1##{CONFIG_ID}##{FIELD}" in mapped_keys
+
+        # Duplicate skipped
+        result = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            mapped_keys=mapped_keys,
+        )
+        assert result is None
+
+    def test_mapped_keys_prevents_duplicate_qualifier(self) -> None:
+        mapped_keys: set[str] = set()
+        qual = "my.qual"
+        mappings = _mapping("s1", {CONFIG_ID: {qual: {FIELD: 77}}})
+
+        val1, _ = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            mapped_keys=mapped_keys,
+            extra_qualifiers=[qual],
+        )
+        assert val1 == 77
+        assert f"s1##{CONFIG_ID}##{qual}##{FIELD}" in mapped_keys
+
+        # Duplicate skipped — only the generic key (not present) is re-checked
+        result = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            mapped_keys=mapped_keys,
+            extra_qualifiers=[qual],
+        )
+        assert result is None
+
+    def test_different_sources_not_deduped(self) -> None:
+        """mapped_keys are source-scoped — same field from a different source is applied."""
+        mapped_keys: set[str] = set()
+        m1 = _mapping("s1", {FIELD: 10})
+        m2 = _mapping("s2", {FIELD: 20})
+
+        resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=m1,
+            mapped_keys=mapped_keys,
+        )
+        val, prov = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=m2,
+            mapped_keys=mapped_keys,
+        )
+        assert val == 20
+        assert prov.source == "s2"
+
+    def test_none_mapped_keys_allows_all(self) -> None:
+        """Without mapped_keys, every call applies (no dedup)."""
+        mappings = _mapping("s1", {FIELD: 10})
+        v1, _ = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        v2, _ = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert v1 == v2 == 10
+
+
+# ---------------------------------------------------------------------------
+# resolve_env_var — env-var resolution and provenance
+# ---------------------------------------------------------------------------
+
+
+class TestResolveEnvVar:
+    """Exercise ``resolve_env_var`` through env-var paths in ``resolve_field``."""
+
+    def _unique_key(self) -> str:
+        return f"CISTELL_TEST_{uuid.uuid4().hex[:8].upper()}"
+
+    def test_class_env_key_resolved(self) -> None:
+        key = self._unique_key()
+        os.environ[key] = "hello"
+        try:
+            val, prov = resolve_field(FIELD, CONFIG_ID, key, GENERIC_ENV)
+            assert val == "hello"
+            assert prov.source == f"env var '{key}'"
+            assert prov.is_default is False
+        finally:
+            del os.environ[key]
+
+    def test_generic_env_key_resolved(self) -> None:
+        key = self._unique_key()
+        os.environ[key] = "world"
+        try:
+            dummy_class = self._unique_key()  # not set
+            val, prov = resolve_field(FIELD, CONFIG_ID, dummy_class, key)
+            assert val == "world"
+            assert prov.source == f"env var '{key}'"
+        finally:
+            del os.environ[key]
+
+    def test_class_env_beats_generic(self) -> None:
+        class_key = self._unique_key()
+        generic_key = self._unique_key()
+        os.environ[class_key] = "class"
+        os.environ[generic_key] = "generic"
+        try:
+            val, prov = resolve_field(FIELD, CONFIG_ID, class_key, generic_key)
+            assert val == "class"
+            assert class_key in prov.source
+        finally:
+            del os.environ[class_key]
+            del os.environ[generic_key]
+
+    def test_env_var_beats_mapping(self) -> None:
+        key = self._unique_key()
+        os.environ[key] = "from_env"
+        mappings = _mapping("file", {FIELD: "from_file"})
+        try:
+            val, prov = resolve_field(
+                FIELD, CONFIG_ID, key, GENERIC_ENV, mappings=mappings
+            )
+            assert val == "from_env"
+            assert "env var" in prov.source
+        finally:
+            del os.environ[key]
+
+    def test_missing_env_var_falls_through(self) -> None:
+        missing = self._unique_key()
+        result = resolve_field(FIELD, CONFIG_ID, missing, missing)
+        assert result is None
+
+    def test_secret_flag_propagated(self) -> None:
+        key = self._unique_key()
+        os.environ[key] = "s3cr3t"
+        try:
+            _, prov = resolve_field(FIELD, CONFIG_ID, key, GENERIC_ENV, secret=True)
+            assert prov.is_secret is True
+        finally:
+            del os.environ[key]
+
+    def test_extra_env_keys_highest_priority(self) -> None:
+        """extra_env_keys beat class and generic env keys."""
+        class_key = self._unique_key()
+        extra_key = self._unique_key()
+        os.environ[class_key] = "class"
+        os.environ[extra_key] = "extra"
+        try:
+            val, prov = resolve_field(
+                FIELD,
+                CONFIG_ID,
+                class_key,
+                GENERIC_ENV,
+                extra_env_keys=[extra_key],
+            )
+            assert val == "extra"
+            assert extra_key in prov.source
+        finally:
+            del os.environ[class_key]
+            del os.environ[extra_key]
+
+    def test_extra_env_keys_last_wins(self) -> None:
+        """When multiple extra env keys are set, the last one in the list wins."""
+        k1 = self._unique_key()
+        k2 = self._unique_key()
+        os.environ[k1] = "first"
+        os.environ[k2] = "second"
+        try:
+            val, prov = resolve_field(
+                FIELD,
+                CONFIG_ID,
+                CLASS_ENV,
+                GENERIC_ENV,
+                extra_env_keys=[k1, k2],
+            )
+            assert val == "second"
+            assert k2 in prov.source
+        finally:
+            del os.environ[k1]
+            del os.environ[k2]
+
+    def test_extra_env_keys_missing_falls_to_class(self) -> None:
+        """If extra env keys are not set, class env key is used."""
+        class_key = self._unique_key()
+        os.environ[class_key] = "class"
+        missing = self._unique_key()
+        try:
+            val, _ = resolve_field(
+                FIELD,
+                CONFIG_ID,
+                class_key,
+                GENERIC_ENV,
+                extra_env_keys=[missing],
+            )
+            assert val == "class"
+        finally:
+            del os.environ[class_key]
+
+
+# ---------------------------------------------------------------------------
+# Priority ordering — end-to-end through all helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityOrdering:
+    """Verify the full priority chain: generic < class < qualifier < env."""
+
+    def test_class_specific_beats_generic(self) -> None:
+        mappings = _mapping("src", {FIELD: 1, CONFIG_ID: {FIELD: 2}})
+        val, _ = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert val == 2
+
+    def test_qualifier_beats_class_specific(self) -> None:
+        mappings = _mapping(
+            "src",
+            {CONFIG_ID: {FIELD: 2, "q": {FIELD: 3}}},
+        )
+        val, _ = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            extra_qualifiers=["q"],
+        )
+        assert val == 3
+
+    def test_later_qualifier_beats_earlier(self) -> None:
+        mappings = _mapping(
+            "src",
+            {CONFIG_ID: {"q1": {FIELD: 10}, "q2": {FIELD: 20}}},
+        )
+        val, _ = resolve_field(
+            FIELD,
+            CONFIG_ID,
+            CLASS_ENV,
+            GENERIC_ENV,
+            mappings=mappings,
+            extra_qualifiers=["q1", "q2"],
+        )
+        assert val == 20
+
+    def test_later_source_beats_earlier(self) -> None:
+        mappings = [("low", {FIELD: 1}), ("high", {FIELD: 2})]
+        val, prov = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert val == 2
+        assert prov.source == "high"
+
+    def test_provenance_source_tracks_winning_mapping(self) -> None:
+        mappings = [("fileA", {FIELD: 1}), ("fileB", {CONFIG_ID: {FIELD: 2}})]
+        _, prov = resolve_field(
+            FIELD, CONFIG_ID, CLASS_ENV, GENERIC_ENV, mappings=mappings
+        )
+        assert prov.source == "fileB"


### PR DESCRIPTION
Allow ConfigBase subclasses to inject higher-priority mapping subsections
and environment variable keys via get_extra_qualifiers() and
get_extra_env_keys() hooks, without reimplementing the resolution loop.

Bump version to 0.1.2.